### PR TITLE
Add release note link

### DIFF
--- a/sofa-boot/zh_CN/SUMMARY.md
+++ b/sofa-boot/zh_CN/SUMMARY.md
@@ -49,4 +49,5 @@
   - [参与贡献](./sofa-jarslink/contribution)
 - 升级文档
   - [SOFABoot 2.5.x 升级注意文档](upgrade_2_5_x)
+- [发布历史](https://github.com/alipay/sofa-boot/releases)
 - [FAQ](./FAQ)

--- a/sofa-tracer/zh_CN/SUMMARY.md
+++ b/sofa-tracer/zh_CN/SUMMARY.md
@@ -15,6 +15,7 @@
      * [SOFARPC 日志](./SOFARPC)
      * [HttpClient 日志](./HttpClient)
      * [DataSource 日志](./Datasource)
+- [发布历史](https://github.com/alipay/sofa-tracer/releases)
 - [RoadMap](./RoadMap)
 
 


### PR DESCRIPTION
Add release note link to SOFABoot and SOFATracer document, so users could acess release note more quickly.