### PR TITLE
update hystrix docs

### DIFF
--- a/sofa-rpc/zh_CN/Fault-Hystrix.md
+++ b/sofa-rpc/zh_CN/Fault-Hystrix.md
@@ -14,17 +14,19 @@ SOFA RPC 已集成 Hystrix 提供熔断能力，当前提供第一个预览版�
         <version>1.5.12</version>
 </dependency>
 ```
-2. 显示开启 `Hystrix` 能力，注入 `HystrixFilter`：
+2. 通过配置显式开启 `Hystrix`，将会自动加载 `HystrixFilter`：
 ```java
+// 全局开启
+RpcConfigs.putValue(HystrixConstants.SOFA_HYSTRIX_ENABLED, true);
+// 对特定 Consumer 开启
 ConsumerConfig<HelloService> consumerConfig = new ConsumerConfig<HelloService>()
         .setInterfaceId(HelloService.class.getName())
-        .setParameter(HystrixConstants.SOFA_HYSTRIX_ENABLED, String.valueOf(true))
-        .setFilterRef(Collections.<Filter> singletonList(new HystrixFilter()));
+        .setParameter(HystrixConstants.SOFA_HYSTRIX_ENABLED, String.valueOf(true));
 ```
 
 ### FallbackFactory
 
-`FallbackFactory` 提供接口主要提供 `Fallback` 实现的注入能力。
+`FallbackFactory` 接口主要提供 `Fallback` 实现的注入能力，用于在 `Hystrix` 执行出现异常（抛出异常、超时、线程池拒绝和熔断等）时自动执行降级逻辑。
 
 1. 定义接口 `Fallback` 实现：
 ```java
@@ -39,14 +41,13 @@ public class HelloServiceFallback implements HelloService {
 ```java
 ConsumerConfig<HelloService> consumerConfig = new ConsumerConfig<HelloService>()
         .setInterfaceId(HelloService.class.getName())
-        .setParameter(HystrixConstants.SOFA_HYSTRIX_ENABLED, String.valueOf(true))
-        .setFilterRef(Collections.<Filter> singletonList(new HystrixFilter()));
+        .setParameter(HystrixConstants.SOFA_HYSTRIX_ENABLED, String.valueOf(true));
 // 可以直接使用默认的 FallbackFactory 直接注入 Fallback 实现
 SofaHystrixConfig.registerFallback(consumerConfig, new HelloServiceFallback());
 // 也可以自定义 FallbackFactory 直接注入 FallbackFactory
 SofaHystrixConfig.registerFallbackFactory(consumerConfig, new HelloServiceFallbackFactory());
 ```
-3. 当服务端响应失败时，客户端可以触发 `Fallback` 逻辑执行。
+3. 当服务端响应失败时，客户端会自动触发 `Fallback` 逻辑执行。
 
 ### SetterFactory
 
@@ -55,8 +56,11 @@ SofaHystrixConfig.registerFallbackFactory(consumerConfig, new HelloServiceFallba
 SofaHystrixConfig.registerSetterFactory(consumerConfig, new CustomSetterFactory());
 ```
 
+默认提供的实现中 `GroupKey` 为 `InterfaceId`，`CommandKey` 为方法的名称。
+
 ### 支持 Hystrix 的版本信息
 
 SOFA RPC: [5.5.0](https://github.com/alipay/sofa-rpc/releases), SOFA Boot: [2.5.3](https://github.com/alipay/sofa-boot/releases/)。
 
 SOAF RPC 集成验证 Hystrix 版本：`1.5.12`。
+


### PR DESCRIPTION
1. `HystrixFilter` is an auto-active(`@AutoActive`) filter, it does not need to be explicitly added by `setFilterRef`.
2. fix some typos and add more describetions.